### PR TITLE
Cm iteration two

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,52 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    abstract_type (0.0.7)
+    adamantium (0.2.0)
+      ice_nine (~> 0.11.0)
+      memoizable (~> 0.4.0)
+    ast (2.1.0)
+    cane (2.6.2)
+      parallel
+    concord (0.1.5)
+      adamantium (~> 0.2.0)
+      equalizer (~> 0.0.9)
+    diff-lcs (1.2.5)
+    equalizer (0.0.11)
+    ice_nine (0.11.1)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    minitest (5.10.1)
+    parallel (1.6.1)
+    parser (2.2.2.6)
+      ast (>= 1.1, < 3.0)
+    private_attr (1.1.0)
+    procto (0.0.2)
+    rainbow (2.0.0)
+    rake (12.0.0)
+    reek (3.4.0)
+      parser (~> 2.2.2.5)
+      private_attr (~> 1.1)
+      rainbow (~> 2.0)
+      unparser (~> 0.2.2)
+    thread_safe (0.3.5)
+    unparser (0.2.4)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      concord (~> 0.1.5)
+      diff-lcs (~> 1.2.5)
+      equalizer (~> 0.0.9)
+      parser (~> 2.2.2)
+      procto (~> 0.0.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cane
+  minitest
+  rake
+  reek
+
+BUNDLED WITH
+   1.13.6

--- a/lib/enrollment_repository.rb
+++ b/lib/enrollment_repository.rb
@@ -13,25 +13,40 @@ class EnrollmentRepository
   def load_data(data)
     contents = load_files(data)
     kindergarten = contents[:kindergarten]
-    enrollment_maker(kindergarten)
+    high_school_graduation = contents[:high_school_graduation]
+    #enrollment maker takes more args or maybe the hash or an array
+    enrollment_maker(kindergarten, high_school_graduation)
   end
 
-  def enrollment_maker(contents)
-    contents.each do |row|
+  def enrollment_maker(kindergarten, high_school_graduation)
+    kindergarten.each do |row|
       name = row[:location].upcase
       year, occupancy = kindergarten_participation_yearly(row)
       if @enrollments.has_key?(name)
         @enrollments[name].identifier[:kindergarten_participation][year] = occupancy
       else
         enrollment = Enrollment.new({ :name => name,
-          :kindergarten_participation => { year => occupancy }})
+          :kindergarten_participation => { year => occupancy },
+          :high_school_graduation => {}})
         @enrollments[name] = enrollment
+      end
+    end
+
+    unless high_school_graduation.nil?
+      high_school_graduation.each do |row|
+        name = row[:location].upcase
+        year, data = high_school_graduation_yearly(row)
+          @enrollments[name].identifier[:high_school_graduation][year] = data
       end
     end
   end
 
   def kindergarten_participation_yearly(row)
-    [clean_year(row[:timeframe]).to_i, clean_occupancy(row[:data]).to_f]
+    [clean_year(row[:timeframe]).to_i, clean_occupancy(row[:data]).to_f.round(3)]
+  end
+
+  def high_school_graduation_yearly(row)
+    [clean_year(row[:timeframe]).to_i, clean_occupancy(row[:data]).to_f.round(3)]
   end
 
   def clean_occupancy(occupancy)

--- a/lib/enrollment_repository.rb
+++ b/lib/enrollment_repository.rb
@@ -19,7 +19,12 @@ class EnrollmentRepository
   end
 
   def enrollment_maker(kindergarten, high_school_graduation)
-    kindergarten.each do |row|
+    add_kindergarten_participation_data(kindergarten)
+    add_high_school_graduation_data(high_school_graduation)
+  end
+
+  def add_kindergarten_participation_data(file)
+    file.each do |row|
       name = row[:location].upcase
       year, occupancy = kindergarten_participation_yearly(row)
       if @enrollments.has_key?(name)
@@ -31,9 +36,11 @@ class EnrollmentRepository
         @enrollments[name] = enrollment
       end
     end
+  end
 
-    unless high_school_graduation.nil?
-      high_school_graduation.each do |row|
+  def add_high_school_graduation_data(file)
+    unless file.nil?
+      file.each do |row|
         name = row[:location].upcase
         year, data = high_school_graduation_yearly(row)
           @enrollments[name].identifier[:high_school_graduation][year] = data

--- a/lib/headcount_analyst.rb
+++ b/lib/headcount_analyst.rb
@@ -1,7 +1,3 @@
-require_relative 'enrollment'
-require_relative 'enrollment_repository'
-require_relative 'district_repository'
-require_relative 'district'
 require 'pry'
 
 class HeadcountAnalyst

--- a/test/district_test.rb
+++ b/test/district_test.rb
@@ -47,6 +47,6 @@ class DistrictTest < Minitest::Test
   def test_district_can_get_enrollment_occupancy_for_year
     dr.load_data({:enrollment => {:kindergarten => './test/fixtures/Kindergarten_sample_data.csv'}})
     enrollment = district.enrollment
-    assert_equal 0.39159, district.enrollment.kindergarten_participation_in_year(2007)
+    assert_equal 0.392, district.enrollment.kindergarten_participation_in_year(2007)
   end
 end

--- a/test/enrollment_repository_test.rb
+++ b/test/enrollment_repository_test.rb
@@ -71,21 +71,20 @@ class EnrollmentRepositoryTest < Minitest::Test
     enrollment = er.find_by_name("ACADEMY 20")
     assert_equal "ACADEMY 20", enrollment.name
     assert_equal Enrollment, enrollment.class
-    assert_equal 0.39159, enrollment.kindergarten_participation_in_year(2007)
-    assert_equal 0.26709, enrollment.kindergarten_participation_in_year(2005)
+    assert_equal 0.392, enrollment.kindergarten_participation_in_year(2007)
+    assert_equal 0.267, enrollment.kindergarten_participation_in_year(2005)
   end
 
   def test_adds_high_school_grad_data_in_load
-    skip
-    er_2.new_load_data({:enrollment => {:kindergarten => './test/fixtures/Kindergarten_sample_data.csv',
+    er_2.load_data({:enrollment => {:kindergarten => './test/fixtures/Kindergarten_sample_data.csv',
       :high_school_graduation => './test/fixtures/high_school_graduation_rates_sample.csv'}})
     enrollment = er_2.find_by_name("acaDEmy 20")
     assert_equal "ACADEMY 20", enrollment.name
     assert_equal Enrollment, enrollment.class
-    assert_equal 0.39159, enrollment.kindergarten_participation_in_year(2007)
-    assert_equal 0.26709, enrollment.kindergarten_participation_in_year(2005)
-    assert_equal 0.89500, enrollment.graduation_rate_in_year(2010)
-    assert_equal 0.89800, enrollment.graduation_rate_in_year(2014)
+    assert_equal 0.392, enrollment.kindergarten_participation_in_year(2007)
+    assert_equal 0.267, enrollment.kindergarten_participation_in_year(2005)
+    assert_equal 0.895, enrollment.graduation_rate_in_year(2010)
+    assert_equal 0.898, enrollment.graduation_rate_in_year(2014)
     expected = { 2010 => 0.895, 2011 => 0.895, 2012 => 0.889,
       2013 => 0.913, 2014 => 0.898 }
     assert_equal expected, enrollment.graduation_rate_by_year

--- a/test/enrollment_repository_test.rb
+++ b/test/enrollment_repository_test.rb
@@ -75,18 +75,38 @@ class EnrollmentRepositoryTest < Minitest::Test
     assert_equal 0.267, enrollment.kindergarten_participation_in_year(2005)
   end
 
+  def test_returns_correctly_formatted_data_for_hs_graduation
+    er_2.load_data({:enrollment => {:kindergarten => './test/fixtures/Kindergarten_sample_data.csv',
+      :high_school_graduation => './test/fixtures/high_school_graduation_rates_sample.csv'}})
+    row_1 = "ACADEMY 20,2012,Percent,0.88983"
+    row_2 = "ADAMS COUNTY 14,2012,Percent,0.63372"
+    year_1, year_2 = ["2012", "2012"]
+    data_1, data_2 = ["0.88983", "0.63372"]
+    assert_equal "2012", er.clean_year(year_1)
+    assert_equal "2012", er.clean_year(year_2)
+    assert_in_delta 0.889, er.clean_occupancy(data_1).to_f.round(3), 0.005
+    assert_in_delta 0.634, er.clean_occupancy(data_2).to_f.round(3), 0.005
+  end
+
   def test_adds_high_school_grad_data_in_load
     er_2.load_data({:enrollment => {:kindergarten => './test/fixtures/Kindergarten_sample_data.csv',
       :high_school_graduation => './test/fixtures/high_school_graduation_rates_sample.csv'}})
     enrollment = er_2.find_by_name("acaDEmy 20")
+
     assert_equal "ACADEMY 20", enrollment.name
     assert_equal Enrollment, enrollment.class
+
     assert_equal 0.392, enrollment.kindergarten_participation_in_year(2007)
     assert_equal 0.267, enrollment.kindergarten_participation_in_year(2005)
     assert_equal 0.895, enrollment.graduation_rate_in_year(2010)
     assert_equal 0.898, enrollment.graduation_rate_in_year(2014)
+
     expected = { 2010 => 0.895, 2011 => 0.895, 2012 => 0.889,
       2013 => 0.913, 2014 => 0.898 }
-    assert_equal expected, enrollment.graduation_rate_by_year
+    actual = enrollment.graduation_rate_by_year
+    
+    expected.each_pair do |year, data|
+      assert_in_delta data, actual[year], 0.005
+    end
   end
 end

--- a/test/enrollment_test.rb
+++ b/test/enrollment_test.rb
@@ -45,7 +45,6 @@ class EnrollmentTest < Minitest::Test
   end
 
   def test_grad_rate_by_year
-
     result = { 2010 => 0.895, 2011 => 0.895, 2012 => 0.889, 2013 => 0.913, 2014 => 0.898 }
     assert_equal result, enrollment.graduation_rate_by_year
   end

--- a/test/headcount_analyst_test.rb
+++ b/test/headcount_analyst_test.rb
@@ -29,8 +29,8 @@ class HeadcountAnalystTest < Minitest::Test
     data = [0.39159, 0.35364, 0.26709, 0.30201, 0.38456, 0.3900,
       0.43628, 0.48900, 0.47883, 0.48774, 0.49022]
     expected = (data.reduce(:+) / data.count)
-    assert_equal expected.round(5), actual
-    assert_equal 0.53039, ha.find_average('COLORADO')
+    assert_in_delta expected.round(5), actual, 0.005
+    assert_in_delta 0.53039, ha.find_average('COLORADO'), 0.005
   end
 
   def test_can_compare_two_averages

--- a/test/headcount_analyst_test.rb
+++ b/test/headcount_analyst_test.rb
@@ -68,5 +68,4 @@ class HeadcountAnalystTest < Minitest::Test
     assert_raises(NameError) { ha.find_enrollment("MADEUP NAME") }
     assert_raises(NameError) { ha.kindergarten_participation_rate_variation('UNKNOWN 20', against: 'ARIZONA') }
   end
-
 end


### PR DESCRIPTION
-adds high school grad data to enrollment objects in EnrollmentRepo
--enrollment maker broken up into 2 methods: #add_kindergarten_participation_data & #add_high_school_graduation_data
-includes integration tests for enrollment repo and enrollment class
-changes tests throughout to be assert_in_delta due to rounding
