### PR TITLE
Cm iteration five

### DIFF
--- a/lib/headcount_analyst.rb
+++ b/lib/headcount_analyst.rb
@@ -117,7 +117,13 @@ class HeadcountAnalyst
 		raise(InsufficientInformationError) if settings[:grade].nil?
 		raise(UnknownDataError) if ![3, 8].include?(settings[:grade])
 		calculate_all_year_over_year_growths(settings)
-		@swtests_year_growth.sort_by { |name, growth| growth }.reverse.first
+		if settings[:top].nil?
+			@swtests_year_growth.sort_by { |name, growth| growth }.reverse.first
+		else
+			count = settings[:top] - 1
+			sorted = @swtests_year_growth.sort_by { |name, growth| growth }.reverse
+			(0..count).to_a.map { |i| sorted[i] }
+		end
 	end
 
 	def calculate_all_year_over_year_growths(settings)

--- a/lib/insufficient_information_error.rb
+++ b/lib/insufficient_information_error.rb
@@ -1,0 +1,2 @@
+class InsufficientInformationError < Exception
+end 

--- a/test/district_repository_test.rb
+++ b/test/district_repository_test.rb
@@ -121,7 +121,6 @@ class DistrictRepositoryTest < Minitest::Test
     :free_or_reduced_price_lunch => "./test/fixtures/Students_qualifying_for_free_or_reduced_price_lunch.csv",
     :title_i => "./test/fixtures/Title_I_students.csv"
   }})
-  binding.pry
     district = dr.find_by_name('ACADEMY 20')
     ep = dr.epr.find_by_name('ACADEMY 20')
     assert_equal 'ACADEMY 20', ep.name

--- a/test/district_repository_test.rb
+++ b/test/district_repository_test.rb
@@ -121,6 +121,7 @@ class DistrictRepositoryTest < Minitest::Test
     :free_or_reduced_price_lunch => "./test/fixtures/Students_qualifying_for_free_or_reduced_price_lunch.csv",
     :title_i => "./test/fixtures/Title_I_students.csv"
   }})
+  binding.pry
     district = dr.find_by_name('ACADEMY 20')
     ep = dr.epr.find_by_name('ACADEMY 20')
     assert_equal 'ACADEMY 20', ep.name

--- a/test/headcount_analyst_test.rb
+++ b/test/headcount_analyst_test.rb
@@ -159,8 +159,31 @@ class HeadcountAnalystTest < Minitest::Test
     assert_raises(UnknownDataError) { ha_3.top_statewide_test_year_over_year_growth(grade: 9, subject: :math) }
     actual = ha_3.top_statewide_test_year_over_year_growth(grade: 3, subject: :math)
     assert_equal Array, actual.class
-    binding.pry
     assert_equal String, actual[0].class
     assert_equal Float, actual[1].class
+  end
+
+  def test_can_find_top_set_of_performers
+    dr_4 = DistrictRepository.new
+    dr_4.load_data({
+  :enrollment => {
+    :kindergarten => "./test/fixtures/Kindergarten_sample_data.csv",
+    :high_school_graduation => "./test/fixtures/high_school_graduation_rates_sample.csv",
+  },
+  :statewide_testing => {
+    :third_grade => "./test/fixtures/3rd_grade_students_scoring_proficient_or_above_on_the_CSAP_TCAP.csv",
+    :eighth_grade => "./test/fixtures/8th_grade_students_scoring_proficient_or_above_on_the_CSAP_TCAP.csv",
+    :math => "./test/fixtures/Average_proficiency_on_the_CSAP_TCAP_by_race_ethnicity_Math.csv",
+    :reading => "./test/fixtures/Average_proficiency_on_the_CSAP_TCAP_by_race_ethnicity_Reading.csv",
+    :writing => "./test/fixtures/Average_proficiency_on_the_CSAP_TCAP_by_race_ethnicity_Writing.csv"
+  },
+  :economic_profile => {
+    :median_household_income => "./test/fixtures/Median_household_income.csv",
+    :children_in_poverty => "./test/fixtures/School_aged_children_in_poverty.csv",
+    :free_or_reduced_price_lunch => "./test/fixtures/Students_qualifying_for_free_or_reduced_price_lunch.csv",
+    :title_i => "./test/fixtures/Title_I_students.csv"
+  }})
+    ha_3 = HeadcountAnalyst.new(dr_4)
+    ha_3.top_statewide_test_year_over_year_growth(grade: 3, top: 3, subject: :math)
   end
 end

--- a/test/headcount_analyst_test.rb
+++ b/test/headcount_analyst_test.rb
@@ -128,16 +128,15 @@ class HeadcountAnalystTest < Minitest::Test
     :title_i => "./test/fixtures/Title_I_students.csv"
   }})
     statewide_test = dr_3.str.find_by_name('ACADEMY 20')
-    data = ha.year_and_percentage({:subject => :math, :object => statewide_test, :grade => :all})
+    data = ha.year_and_percentage({:subject => :math, :grade => :all}, statewide_test)
     assert_equal Array, data.class
     assert_equal Fixnum, data[0][0].class
     assert_equal Float, data[0][1].class
   end
 
   def test_raises_errors_if_not_given_enough_or_correct_information
-    skip
-    dr_3 = DistrictRepository.new
-    dr_3.load_data({
+    dr_4 = DistrictRepository.new
+    dr_4.load_data({
   :enrollment => {
     :kindergarten => "./test/fixtures/Kindergarten_sample_data.csv",
     :high_school_graduation => "./test/fixtures/high_school_graduation_rates_sample.csv",
@@ -155,11 +154,12 @@ class HeadcountAnalystTest < Minitest::Test
     :free_or_reduced_price_lunch => "./test/fixtures/Students_qualifying_for_free_or_reduced_price_lunch.csv",
     :title_i => "./test/fixtures/Title_I_students.csv"
   }})
-
-    assert_raises(InsufficientInformationError) { ha.top_statewide_test_year_over_year_growth(subject: :math) }
-    assert_raises(UnknownDataError) { ha.top_statewide_test_year_over_year_growth(grade: 9, subject: :math) }
-    actual = ha.top_statewide_test_year_over_year_growth(grade: 3, subject: :math)
+    ha_3 = HeadcountAnalyst.new(dr_4)
+    assert_raises(InsufficientInformationError) { ha_3.top_statewide_test_year_over_year_growth(subject: :math) }
+    assert_raises(UnknownDataError) { ha_3.top_statewide_test_year_over_year_growth(grade: 9, subject: :math) }
+    actual = ha_3.top_statewide_test_year_over_year_growth(grade: 3, subject: :math)
     assert_equal Array, actual.class
+    binding.pry
     assert_equal String, actual[0].class
     assert_equal Float, actual[1].class
   end

--- a/test/insufficient_information_error_test.rb
+++ b/test/insufficient_information_error_test.rb
@@ -1,0 +1,16 @@
+require_relative 'test_helper'
+require './lib/insufficient_information_error'
+
+class InsufficientInformationErrorTest < Minitest::Test
+  def testing_error(value)
+    if value
+      value
+    else
+      raise InsufficientInformationError
+    end
+  end
+
+  def test_it_raises_unknown_race_error
+    assert_raises(InsufficientInformationError) { testing_error(nil) }
+  end
+end


### PR DESCRIPTION
adds insufficient information error in headcount analyst
-also has corresponding test

adds top_statewide_test_year_over_year_growth
-incomplete, needs more tests
-passes current tests & rake

adds helper methods for statewide_test_year_over_year_growth